### PR TITLE
Add Advent Calendars For 2024

### DIFF
--- a/articles/templates/2024/article.pod.tmpl
+++ b/articles/templates/2024/article.pod.tmpl
@@ -147,4 +147,10 @@ L<Space Telescope Advent Calendar (The Atlantic)|https://www.theatlantic.com/pho
 
 L<A(I)dvents calendar|https://www.novalutions.de/en/aidventskalender/>
 
+=head2 Qiita Perl Advent Calendar (Japanese)
+
+L<Qiita Perl Advent Calendar (Japanese)|https://qiita.com/advent-calendar/2024/perl>
+
+L<Translated by Google|https://qiita-com.translate.goog/advent-calendar/2024/perl?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp>
+
 =cut

--- a/articles/templates/2024/article.pod.tmpl
+++ b/articles/templates/2024/article.pod.tmpl
@@ -15,12 +15,17 @@ L<Raku Advent Calendar|https://raku-advent.blog/<TMPL_VAR NAME=YEAR>/>
 
 L<Perl Advent|http://perladvent.org/<TMPL_VAR NAME=YEAR>/<TMPL_VAR NAME=YEAR>-12-<TMPL_VAR NAME=DAY02>.html>
 
+=head2 PDL (Perl Data Language) Advent Calendar
+
+L<PDL (Perl Data Language) Advent Calendar|https://pdl.perl.org/advent/index.html>
+
 
 =head1 Java
 
 =head2 Java Advent
 
 L<Java Advent:|http://www.javaadvent.com/calendar>
+
 
 =head1 C#
 
@@ -39,11 +44,17 @@ L<AdventJS|https://adventjs.dev/>
 
 L<Advent of JavaScript|https://www.adventofjs.com/>
 
+
 =head1 CSS
 
 =head2 Advent of CSS
 
 L<Advent of CSS|https://www.adventofcss.com/>
+
+=head2 CSS Advent Calender
+
+L<CSS Advent Calender|https://cssadventcalendar.dev/>
+
 
 =head1 HTML
 
@@ -51,17 +62,20 @@ L<Advent of CSS|https://www.adventofcss.com/>
 
 L<HTMHell Advent Calendar|https://www.htmhell.dev/adventcalendar/>
 
+
 =head1 TypeScript
 
 =head2 Advent of TypeScript
 
 L<Advent of TypeScript|https://www.adventofts.com/>
 
+
 =head1 SQL
 
 =head2 Advent of SQL
 
 L<Advent of SQL|https://adventofsql.com/>
+
 
 =head1 F#
 
@@ -74,6 +88,14 @@ L<F# Advent Calendar in English|https://sergeytihon.com/fsadvent/>
 =head2 Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin
 
 L<Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin|https://blog.jetbrains.com/kotlin/<TMPL_VAR NAME=YEAR>/11/advent-of-code-<TMPL_VAR NAME=YEAR>-in-kotlin/>
+
+
+=head1 C
+
+=head2 Advent(2) -- The System Call Advent Calendar
+
+L<Advent(2) -- The System Call Advent Calendar|https://www.ibr.cs.tu-bs.de/users/dietrich/advent/index.html>
+
 
 =head1 Miscellaneous
 
@@ -116,5 +138,13 @@ L<Playground to solve the Advent of Code challenges using visual scripting|https
 =head2 Advent of Open Source
 
 L<Advent of Open Source|https://adventofopensource.com/>
+
+=head2 Space Telescope Advent Calendar (The Atlantic)
+
+L<Space Telescope Advent Calendar (The Atlantic)|https://www.theatlantic.com/photo/2024/12/2024-space-telescope-advent-calendar/680839/>
+
+=head2 A(I)dvents calendar
+
+L<A(I)dvents calendar|https://www.novalutions.de/en/aidventskalender/>
 
 =cut

--- a/articles/templates/2024/article.pod.tmpl
+++ b/articles/templates/2024/article.pod.tmpl
@@ -6,7 +6,7 @@ topic:  Advent Planet
 
 =head2 Raku Advent Calendar
 
-L<Raku Advent Calendar|https://raku-advent.blog/category/<TMPL_VAR NAME=YEAR>/>
+L<Raku Advent Calendar|https://raku-advent.blog/<TMPL_VAR NAME=YEAR>/>
 
 
 =head1 Perl
@@ -20,7 +20,7 @@ L<Perl Advent|http://perladvent.org/<TMPL_VAR NAME=YEAR>/<TMPL_VAR NAME=YEAR>-12
 
 =head2 Java Advent
 
-L<Java Advent:|http://www.javaadvent.com/<TMPL_VAR NAME=YEAR>/>>
+L<Java Advent:|http://www.javaadvent.com/calendar>
 
 =head1 C#
 
@@ -37,19 +37,19 @@ L<AdventJS|https://adventjs.dev/>
 
 =head2 Advent of JavaScript
 
-L<Advent of JavaScript|https://<TMPL_VAR NAME=YEAR>.adventofjs.com/>
+L<Advent of JavaScript|https://www.adventofjs.com/>
 
 =head1 CSS
 
 =head2 Advent of CSS
 
-L<Advent of CSS|https://<TMPL_VAR NAME=YEAR>.adventofcss.com/>
+L<Advent of CSS|https://www.adventofcss.com/>
 
 =head1 HTML
 
 =head2 HTMHell Advent Calendar <TMPL_VAR NAME=YEAR>
 
-L<HTMHell Advent Calendar <TMPL_VAR NAME=YEAR>|https://www.htmhell.dev/adventcalendar/>
+L<HTMHell Advent Calendar|https://www.htmhell.dev/adventcalendar/>
 
 =head1 TypeScript
 
@@ -63,12 +63,6 @@ L<Advent of TypeScript|https://www.adventofts.com/>
 
 L<Advent of SQL|https://adventofsql.com/>
 
-=head1 Racket
-
-=head2 Racket
-
-L<Racket|https://racket.discourse.group/invites/VxkBcXY7yL>
-
 =head1 F#
 
 =head2 F# Advent Calendar in English
@@ -80,7 +74,6 @@ L<F# Advent Calendar in English|https://sergeytihon.com/fsadvent/>
 =head2 Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin
 
 L<Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin|https://blog.jetbrains.com/kotlin/<TMPL_VAR NAME=YEAR>/11/advent-of-code-<TMPL_VAR NAME=YEAR>-in-kotlin/>
-
 
 =head1 Miscellaneous
 
@@ -100,27 +93,19 @@ L<Advent of Cyber|https://tryhackme.com/r/christmas>
 
 L<Bekk Christmas|https://www.bekk.christmas/post/2024>
 
-=head2 Festive Tech Calendar <TMPL_VAR NAME=YEAR>
+=head2 Festive Tech Calendar
 
-L<Festive Tech Calendar <TMPL_VAR NAME=YEAR>|https://festivetechcalendar.com/>
+L<Festive Tech Calendar|https://festivetechcalendar.com/>
 
 =head2 MATH+ Advent Calendar
 
 L<MATH+ Advent Calendar|https://www.mathekalender.de/wp/calendar/>
 
-=head2 Plus Magazine (Math)
-
-L<Plus Magazine Advent|https://plus.maths.org/content/plus-advent-calendar-<TMPL_VAR NAME=YEAR>>
-
-=head2 Web Performance Calendar
-
-L<Web Performance Calendar|https://calendar.perfplanet.com/<TMPL_VAR NAME=YEAR>/>
-
 =head2 24 P[ULL] R[EQUEST]S - Giving Back to Open Source for the Holidays
 
 L<24 P[ULL] R[EQUEST]S|https://24pullrequests.com/>
 
-=head2 Kodekalender 2024
+=head2 Kodekalender 2024 (Norwegian)
 
 L<Kodekalender 2024|https://julekalender.knowit.no/>
 

--- a/articles/templates/2024/article.pod.tmpl
+++ b/articles/templates/2024/article.pod.tmpl
@@ -6,7 +6,8 @@ topic:  Advent Planet
 
 =head2 Raku Advent Calendar
 
-L<Raku Advent|https://rakuadventcalendar.wordpress.com/<TMPL_VAR NAME=YEAR>/12/<TMPL_VAR NAME=DAY02>/>
+L<Raku Advent Calendar|https://raku-advent.blog/category/<TMPL_VAR NAME=YEAR>/>
+
 
 =head1 Perl
 
@@ -14,13 +15,19 @@ L<Raku Advent|https://rakuadventcalendar.wordpress.com/<TMPL_VAR NAME=YEAR>/12/<
 
 L<Perl Advent|http://perladvent.org/<TMPL_VAR NAME=YEAR>/<TMPL_VAR NAME=YEAR>-12-<TMPL_VAR NAME=DAY02>.html>
 
-=head2 Weekly Challenge
 
-1-24:L<Perl Weekly Challenge|https://theweeklychallenge.org/blog/advent-calendar-<TMPL_VAR NAME=YEAR>-12-<TMPL_VAR NAME=DAY02>/>
+=head1 Java
 
-=head2 Perl Dancer Advent Calendar
+=head2 Java Advent
 
-13-24:L<The Twelve Days of Dancer|https://advent.perldancer.org/2023<TMPL_VAR NAME=DAY02>/>
+L<Java Advent:|http://www.javaadvent.com/<TMPL_VAR NAME=YEAR>/>>
+
+=head1 C#
+
+=head2 C# Advent Calendar 2024
+
+L<C# Advent Calendar 2024|https://csadvent.christmas/>
+
 
 =head1 JavaScript
 
@@ -30,95 +37,99 @@ L<AdventJS|https://adventjs.dev/>
 
 =head2 Advent of JavaScript
 
-L<Advent of JavaScript|https://www.adventofjs.com/>
+L<Advent of JavaScript|https://<TMPL_VAR NAME=YEAR>.adventofjs.com/>
 
-=head1 Python
+=head1 CSS
 
-=head2 SCI Python Advent Calendar
+=head2 Advent of CSS
 
-L<Python Advent Calendar|https://scipython.com/apps/adventcalendar/>
+L<Advent of CSS|https://<TMPL_VAR NAME=YEAR>.adventofcss.com/>
 
-#=head1 Ruby
-#
-#=head2 Qiita: Ruby
-#
-#L<Qiita Ruby Advent <TMPL_VAR NAME=YEAR>|http://qiita.com/advent-calendar/<TMPL_VAR NAME=YEAR>/ruby>
-#
-#=head2 Qiita: Ruby on Rails
-#
-#L<Qiita Ruby on Rails Advent <TMPL_VAR NAME=YEAR>|http://qiita.com/advent-calendar/<TMPL_VAR NAME=YEAR>/rails>
+=head1 HTML
 
-=head1 Java
+=head2 HTMHell Advent Calendar <TMPL_VAR NAME=YEAR>
 
-=head2 Java Advent
+L<HTMHell Advent Calendar <TMPL_VAR NAME=YEAR>|https://www.htmhell.dev/adventcalendar/>
 
-L<Java Advent:|http://www.javaadvent.com/<TMPL_VAR NAME=YEAR>/>>
+=head1 TypeScript
 
-#=head2 Java Security Advent Calendar 
-#L<Java Security Advent|https://www.ripstech.com/java-security-calendar-<TMPL_VAR NAME=YEAR>/>
+=head2 Advent of TypeScript
 
-#=head1 Amazon Web Services
-#
-#=head2 AWS Advent
-#
-#L<AWS Advent:|http://www.awsadvent.com/<TMPL_VAR NAME=YEAR>/12/<TMPL_VAR NAME=DAY02>/>
+L<Advent of TypeScript|https://www.adventofts.com/>
+
+=head1 SQL
+
+=head2 Advent of SQL
+
+L<Advent of SQL|https://adventofsql.com/>
+
+=head1 Racket
+
+=head2 Racket
+
+L<Racket|https://racket.discourse.group/invites/VxkBcXY7yL>
+
+=head1 F#
+
+=head2 F# Advent Calendar in English
+
+L<F# Advent Calendar in English|https://sergeytihon.com/fsadvent/>
+
+=head1 Kotlin
+
+=head2 Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin
+
+L<Solve Advent of Code <TMPL_VAR NAME=YEAR> Puzzles in Kotlin|https://blog.jetbrains.com/kotlin/<TMPL_VAR NAME=YEAR>/11/advent-of-code-<TMPL_VAR NAME=YEAR>-in-kotlin/>
+
 
 =head1 Miscellaneous
 
-=head2 YAMLScript Advent
-
-L<YAMLScript Advent|https://yamlscript.org/posts/advent-<TMPL_VAR NAME=YEAR>/dec-<TMPL_VAR NAME=DAY02>/>
-
-#=head2 24Ways Advent
-
-#L<24 Ways to impress your friends|http://24ways.org/<TMPL_VAR NAME=YEAR>/>
-
-#=head2 24 Accessibitly
-#
-#L<24 Days of digital accessibility gifts during the season of giving and sharing|https://www.24a11y.com/<TMPL_VAR NAME=YEAR>/>
-
-=head2 Lean UXmas
-
-L<Lean UXmas|https://<TMPL_VAR NAME=YEAR>.leanuxmas.com/>
-
 =head2 Advent of Code
 
-L<Advent of Code|http://adventofcode.com/<TMPL_VAR NAME=YEAR>/day/<TMPL_VAR NAME=DAY>>
+L<Advent of Code|http://adventofcode.com/<TMPL_VAR NAME=YEAR>/day/<TMPL_VAR NAME=DAY>>>
 
-=head2 QEMU Advent Calendar
+=head2 Everybody Codes
 
-L<QEMU Advent Calendar|http://www.qemu-advent-calendar.org/<TMPL_VAR NAME=YEAR>/> - An amazing QEMU disk image every day.
+L<Everybody Codes|https://everybody.codes/home>
 
-=head2 Advent of Cyber 2023
+=head2 Advent of Cyber 2024
 
 L<Advent of Cyber|https://tryhackme.com/r/christmas>
 
-=head2 Steam Games Advent Calendar
+=head2 Bekk Christmas
 
-L<Steam|https://store.steampowered.com/app/2445940/Games_Advent_Calendar__25_Days__25_Surprises/>
+L<Bekk Christmas|https://www.bekk.christmas/post/2024>
 
-#=head2 Wordpress Snippets
-#
-#L<Wordpress Snippets til Christmas|https://advent.elliottrichmond.co.uk/>
-#
-#=head2 Ladies of Code
-#
-#L<Ladies of Code Advent|https://codecalendar.dev/<TMPL_VAR NAME=YEAR/>>
+=head2 Festive Tech Calendar <TMPL_VAR NAME=YEAR>
 
-#=head2 Andrew Shitov's Blog: Advent Calendar
-#
-#L<Andrew Shitov's Blog|https://andrewshitov.com/<TMPL_VAR NAME=YEAR>/12/<TMPL_VAR NAME=DAY02>/>
+L<Festive Tech Calendar <TMPL_VAR NAME=YEAR>|https://festivetechcalendar.com/>
 
-#=head2 Plus Magazine (Math)
-#
-#L<Plus Magazine Advent|https://plus.maths.org/content/plus-advent-calendar-<TMPL_VAR NAME=YEAR>>
-#
-#=head2 Old English Advent
-#
-#L<The Dictionary of Old English|https://dictionaryofoldenglish.wordpress.com/advent-calendar/>
-#
-#=head2 Gravitational Wave Advent
-#
-#L<Gravitational Wave Advent|https://gravity.astro.cf.ac.uk/advent/>
+=head2 MATH+ Advent Calendar
+
+L<MATH+ Advent Calendar|https://www.mathekalender.de/wp/calendar/>
+
+=head2 Plus Magazine (Math)
+
+L<Plus Magazine Advent|https://plus.maths.org/content/plus-advent-calendar-<TMPL_VAR NAME=YEAR>>
+
+=head2 Web Performance Calendar
+
+L<Web Performance Calendar|https://calendar.perfplanet.com/<TMPL_VAR NAME=YEAR>/>
+
+=head2 24 P[ULL] R[EQUEST]S - Giving Back to Open Source for the Holidays
+
+L<24 P[ULL] R[EQUEST]S|https://24pullrequests.com/>
+
+=head2 Kodekalender 2024
+
+L<Kodekalender 2024|https://julekalender.knowit.no/>
+
+=head2 Advent of Nocode
+
+L<Playground to solve the Advent of Code challenges using visual scripting|https://luna-park.app/advent>
+
+=head2 Advent of Open Source
+
+L<Advent of Open Source|https://adventofopensource.com/>
 
 =cut


### PR DESCRIPTION
Add the following calendars for 2024:

- https://blog.jetbrains.com/kotlin/2024/11/advent-of-code-2024-in-kotlin/
- https://sergeytihon.com/fsadvent/
- https://adventofsql.com/
- https://www.adventofts.com/
- https://www.htmhell.dev/adventcalendar/
- https://adventofcss.com/
- https://www.adventofjs.com/
- https://adventjs.dev/
- https://www.csadvent.christmas/
- https://www.javaadvent.com/
- https://perladvent.org/
- https://raku-advent.blog/

- https://adventofcode.com/
- https://www.mathekalender.de/wp/calendar/
- https://festivetechcalendar.com/
- https://24pullrequests.com/
- https://adventofopensource.com/