### PR TITLE
fix-2025-calander-urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,4 +89,9 @@
 - CHANGELOG.md: updated
 - templates/articles/2025/article.pod.tmpl: Added links provided by [mikkoi](https://github.com/mikkoi)
 
+## 2025-12-21 - Len Jaffe - lenjaffe@jaffesystems.com
+### fix-2025-calander-urls
+- CHANGELOG.md: updated
+- templates/articles/2025/article.pod.tmpl: comments ruthmalan.com; changed Advent of Craft URLifrom LinkedIn to github
+
 

--- a/articles/templates/2025/article.pod.tmpl
+++ b/articles/templates/2025/article.pod.tmpl
@@ -84,12 +84,12 @@ L<SANS Holiday Hack Challenge™ 2025|https://www.sans.org/cyber-ranges/holiday-
 
 L<Debug December|https://www.debugdecember.com/challenges/<TMPL_VAR NAME=YEAR>/day/<TMPL_VAR NAME=DAY02>>
 
-=head2 Advent(ure) in System Seeing
-
-L<Advent(ure) in System Seeing|https://www.ruthmalan.com/Advent/<TMPL_VAR NAME=YEAR>/Day<TMPL_VAR NAME=DAY>.html>
+#=head2 Advent(ure) in System Seeing
+#
+#L<Advent(ure) in System Seeing|https://www.ruthmalan.com/Advent/<TMPL_VAR NAME=YEAR>/Day<TMPL_VAR NAME=DAY>.html>
 
 =head2 Advent of Craft
 
-L<Advent Of Craft|https://www.linkedin.com/company/advent-of-craft/posts/?feedView=all>
+L<Advent Of Craft|https://www.github.com/advent-of-craft/<TMPL_VAR NAME=YEAR>/tree/main/challenges/day<TMPL_VAR NAME=DAY02>>
 
 =cut


### PR DESCRIPTION
- CHANGELOG.md: updated
- templates/articles/2025/article.pod.tmpl: comments ruthmalan.com; changed Advent of Craft URLifrom LinkedIn to github